### PR TITLE
Some changes to forward $scheme and to log real ip

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -20,6 +20,38 @@ http {
         '"$request" $status $upstream_addr '
         '"$http_referer" "$http_user_agent"';
 
+    # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
+    # scheme used to connect to this server
+    map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+      default $http_x_forwarded_proto;
+      ''      $scheme;
+    }
+
+    # If we receive X-Forwarded-Port, pass it through; otherwise, pass along the
+    # server port the client connected to
+    map $http_x_forwarded_port $proxy_x_forwarded_port {
+      default $http_x_forwarded_port;
+      ''      $server_port;
+    }
+
+    # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
+    # Connection header that may have been passed to this server
+    map $http_upgrade $proxy_connection {
+      default upgrade;
+      '' close;
+    }
+
+    # Apply fix for very long server names
+    server_names_hash_bucket_size 128;
+
+    # Default dhparam
+    # Set appropriate X-Forwarded-Ssl header
+    map $scheme $proxy_x_forwarded_ssl {
+      default off;
+      https on;
+    }
+
+
     server {
         listen 80;
 
@@ -44,8 +76,14 @@ http {
         }
 
         location / {
-            proxy_set_header HOST $host;
-            proxy_set_header X-Forwarded-Proto https;
+
+            set_real_ip_from 0.0.0.0/0;
+            real_ip_header X-Real-IP;
+            real_ip_recursive on;
+
+            proxy_set_header HOST $http_host;
+            proxy_set_header Connection $proxy_connection;
+            proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 


### PR DESCRIPTION
Как оказалось, nginx в логи писал ip-адрес nginx-proxy (172........) для всех запросов. Реальные адреса пользователей не видел. Пофиксил. Заодно пофиксил форвардинг схемы (http или https)